### PR TITLE
Ensured process CWD is synced with powershell Runspace.

### DIFF
--- a/stagetwo/PowerShell.cs
+++ b/stagetwo/PowerShell.cs
@@ -74,6 +74,13 @@ namespace stagetwo
                 System.Console.WriteLine(item.ToString());
             }
             System.Console.WriteLine("END");
+
+            // Match our CWD w/ powershell
+            System.Management.Automation.PowerShell ps2 = System.Management.Automation.PowerShell.Create();
+            ps2.Runspace = runspace;
+            Runspace.DefaultRunspace = runspace;
+            ps2.AddScript("[System.IO.Directory]::SetCurrentDirectory($ExecutionContext.SessionState.Path.CurrentFileSystemLocation)");
+            ps2.Invoke();
         }
 
         public static void init_pshost()
@@ -206,6 +213,13 @@ namespace stagetwo
             ConsoleHost.GetProperty("ShouldEndSession", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(pshost, false);
 
             System.Console.WriteLine("\nINTERACTIVE_COMPLETE");
+
+            // Match our CWD w/ powershell
+            System.Management.Automation.PowerShell ps2 = System.Management.Automation.PowerShell.Create();
+            ps2.Runspace = runspace;
+            Runspace.DefaultRunspace = runspace;
+            ps2.AddScript("[System.IO.Directory]::SetCurrentDirectory($ExecutionContext.SessionState.Path.CurrentFileSystemLocation)");
+            ps2.Invoke();
 
         }
     }


### PR DESCRIPTION
PowerShell Runspace's track a separate working directory from the process itself. As such, odd things were happening when opening relative paths after changed directories in PowerShell. This change simply syncs the process working directory with PowerShell after every PowerShell execution or interactive session.

This is working toward the culprit of calebstewart/pwncat#110 but may not fully fix the issue.